### PR TITLE
Fix 'roundImages'.  Add 'bigImages' and 'imageContentMode'.

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -36,6 +36,8 @@
 	// create the walkthough controller
 	VXWalkthroughViewController* walkthrough = [VXWalkthroughViewController initWithDelegate:self withBackgroundColor:backgroundColor];
 	
+//    walkthrough.roundImages = YES;        // disable/enable roundness
+//    walkthrough.bigImages = YES;          // NO for square image, YES for almost full screen
 	// show it
 	[self presentViewController:walkthrough animated:YES completion:nil];
 }

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -36,8 +36,9 @@
 	// create the walkthough controller
 	VXWalkthroughViewController* walkthrough = [VXWalkthroughViewController initWithDelegate:self withBackgroundColor:backgroundColor];
 	
-//    walkthrough.roundImages = YES;        // disable/enable roundness
+//    walkthrough.roundImages = NO;        // disable/enable roundness
 //    walkthrough.bigImages = YES;          // NO for square image, YES for almost full screen
+//    walkthrough.imageContentMode = UIViewContentModeScaleAspectFill;   // contentMode for the image
 	// show it
 	[self presentViewController:walkthrough animated:YES completion:nil];
 }

--- a/VXWalkthroughViewController/VXWalkthroughPageViewController.h
+++ b/VXWalkthroughViewController/VXWalkthroughPageViewController.h
@@ -29,10 +29,12 @@ enum VXWalkthroughAnimationType{
 @property (nonatomic) NSString *imageName;
 
 @property (nonatomic) NSDictionary *styles;
-@property (nonatomic)  BOOL roundImages;
+@property (nonatomic) BOOL roundImages;
+@property (nonatomic) BOOL bigImages;
 
 
 @property (nonatomic,weak) IBOutlet UIImageView *imageView;
+@property (nonatomic,weak) IBOutlet NSLayoutConstraint *imageViewAspectContstraint;
 @property (nonatomic,weak) IBOutlet UILabel *titleView;
 
 @end

--- a/VXWalkthroughViewController/VXWalkthroughPageViewController.h
+++ b/VXWalkthroughViewController/VXWalkthroughPageViewController.h
@@ -31,7 +31,7 @@ enum VXWalkthroughAnimationType{
 @property (nonatomic) NSDictionary *styles;
 @property (nonatomic) BOOL roundImages;
 @property (nonatomic) BOOL bigImages;
-
+@property (nonatomic) UIViewContentMode imageContentMode;
 
 @property (nonatomic,weak) IBOutlet UIImageView *imageView;
 @property (nonatomic,weak) IBOutlet NSLayoutConstraint *imageViewAspectContstraint;

--- a/VXWalkthroughViewController/VXWalkthroughPageViewController.m
+++ b/VXWalkthroughViewController/VXWalkthroughPageViewController.m
@@ -112,6 +112,11 @@
     }
 }
 
+-(void)setImageContentMode:(UIViewContentMode)imageContentMode {
+    _imageContentMode = imageContentMode;
+    self.imageView.contentMode = imageContentMode;
+}
+
 -(void)viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];
 	

--- a/VXWalkthroughViewController/VXWalkthroughPageViewController.m
+++ b/VXWalkthroughViewController/VXWalkthroughPageViewController.m
@@ -95,6 +95,23 @@
 	self.imageView.hidden = NO;
 	self.imageView.image = [UIImage imageNamed:imageName];
 }
+
+-(void)setBigImages:(BOOL)bigImages {
+    _bigImages = bigImages;
+    if (bigImages) {
+        [self.imageView removeConstraint:self.imageViewAspectContstraint];
+    } else {
+        self.imageViewAspectContstraint = [NSLayoutConstraint constraintWithItem:self.imageView
+                                                                       attribute:NSLayoutAttributeHeight
+                                                                       relatedBy:NSLayoutRelationEqual
+                                                                          toItem:self.imageView
+                                                                       attribute:NSLayoutAttributeWidth
+                                                                      multiplier:1.0f
+                                                                        constant:0.0f];
+        [self.imageView addConstraint:self.imageViewAspectContstraint];
+    }
+}
+
 -(void)viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];
 	

--- a/VXWalkthroughViewController/VXWalkthroughViewController.h
+++ b/VXWalkthroughViewController/VXWalkthroughViewController.h
@@ -47,6 +47,7 @@
 @property (nonatomic) IBOutlet UIButton *closeButton;
 
 @property (nonatomic) BOOL roundImages;
+@property (nonatomic) BOOL bigImages;
 @property (nonatomic) NSDictionary *styles;
 @property (nonatomic) UIColor *backgroundColor;
 

--- a/VXWalkthroughViewController/VXWalkthroughViewController.h
+++ b/VXWalkthroughViewController/VXWalkthroughViewController.h
@@ -48,6 +48,7 @@
 
 @property (nonatomic) BOOL roundImages;
 @property (nonatomic) BOOL bigImages;
+@property (nonatomic) UIViewContentMode imageContentMode;
 @property (nonatomic) NSDictionary *styles;
 @property (nonatomic) UIColor *backgroundColor;
 

--- a/VXWalkthroughViewController/VXWalkthroughViewController.m
+++ b/VXWalkthroughViewController/VXWalkthroughViewController.m
@@ -22,7 +22,8 @@
 	if(self = [super init]) {
 		self.scrollview = [[UIScrollView alloc] init];
 		self.controllers = [NSMutableArray array];
-		self.roundImages = true;
+        self.roundImages = true;
+        self.bigImages = true;
 	};
 	
 	return self;
@@ -38,7 +39,8 @@
 		// Controllers as empty array
 		self.controllers = [NSMutableArray array];
 		self.roundImages = true;
-		
+        self.bigImages = true;
+
 	};
 	
 	return self;
@@ -107,7 +109,8 @@
 	while ([stepText length] != 0 && ![stepText isEqualToString:stepKey]) {
 		VXWalkthroughPageViewController* vc = [stb instantiateViewControllerWithIdentifier:@"WalkthroughPage"];
 		vc.styles = self.styles;
-		vc.roundImages = true;
+        vc.roundImages = self.roundImages;
+        vc.bigImages = self.bigImages;
 
 		vc.view.backgroundColor = self.backgroundColor;
 		vc.titleText = stepText;
@@ -272,6 +275,19 @@
 	[self updateUI];
 }
 
+- (void)setRoundImages:(BOOL)roundImages {
+    _roundImages = roundImages;
+    for (VXWalkthroughPageViewController *controller in self.controllers) {
+        controller.roundImages = roundImages;
+    }
+}
+
+- (void)setBigImages:(BOOL)bigImages {
+    _bigImages = bigImages;
+    for (VXWalkthroughPageViewController *controller in self.controllers) {
+        controller.bigImages = bigImages;
+    }
+}
 /*
 override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
 	println("CHANGE")

--- a/VXWalkthroughViewController/VXWalkthroughViewController.m
+++ b/VXWalkthroughViewController/VXWalkthroughViewController.m
@@ -24,6 +24,7 @@
 		self.controllers = [NSMutableArray array];
         self.roundImages = true;
         self.bigImages = true;
+        self.imageContentMode = UIViewContentModeScaleToFill;
 	};
 	
 	return self;
@@ -40,7 +41,7 @@
 		self.controllers = [NSMutableArray array];
 		self.roundImages = true;
         self.bigImages = true;
-
+        self.imageContentMode = UIViewContentModeScaleToFill;
 	};
 	
 	return self;
@@ -111,6 +112,7 @@
 		vc.styles = self.styles;
         vc.roundImages = self.roundImages;
         vc.bigImages = self.bigImages;
+        vc.imageContentMode = self.imageContentMode;
 
 		vc.view.backgroundColor = self.backgroundColor;
 		vc.titleText = stepText;
@@ -288,6 +290,14 @@
         controller.bigImages = bigImages;
     }
 }
+
+- (void)setImageContentMode:(UIViewContentMode)imageContentMode {
+    _imageContentMode = imageContentMode;
+    for (VXWalkthroughPageViewController *controller in self.controllers) {
+        controller.imageContentMode = imageContentMode;
+    }
+}
+
 /*
 override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
 	println("CHANGE")

--- a/VXWalkthroughViewController/VXWalkthroughViewController.storyboard
+++ b/VXWalkthroughViewController/VXWalkthroughViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -108,6 +108,9 @@
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Things to do" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VKG-4Y-YBN">
                                 <rect key="frame" x="16" y="344" width="288" height="216"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="VKG-4Y-YBN" secondAttribute="height" multiplier="4:3" id="sMp-iJ-kj8"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -120,13 +123,20 @@
                             <constraint firstAttribute="trailingMargin" secondItem="bYs-93-hFW" secondAttribute="trailing" id="XJX-Re-9TN"/>
                             <constraint firstItem="VKG-4Y-YBN" firstAttribute="trailing" secondItem="E7c-iN-OTE" secondAttribute="trailingMargin" id="aKH-Z6-RGq"/>
                             <constraint firstItem="Nl4-Pn-5D4" firstAttribute="top" secondItem="VKG-4Y-YBN" secondAttribute="bottom" constant="8" id="bf4-b4-Rzg"/>
+                            <constraint firstItem="Nl4-Pn-5D4" firstAttribute="top" secondItem="bYs-93-hFW" secondAttribute="bottom" priority="900" constant="40" id="hk9-dC-u1Q"/>
                             <constraint firstItem="bYs-93-hFW" firstAttribute="leading" secondItem="E7c-iN-OTE" secondAttribute="leadingMargin" id="leI-2G-ZgH"/>
                             <constraint firstItem="VKG-4Y-YBN" firstAttribute="leading" secondItem="E7c-iN-OTE" secondAttribute="leadingMargin" id="sdZ-47-g17"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="Sf6-JI-NAG"/>
+                            </mask>
+                        </variation>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="imageView" destination="bYs-93-hFW" id="N7X-o2-aYE"/>
+                        <outlet property="imageViewAspectContstraint" destination="YmA-ds-yU5" id="zkC-bZ-gzS"/>
                         <outlet property="titleView" destination="VKG-4Y-YBN" id="Zfz-84-PNB"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
Fixed an issue where the 'roundImages' attributed didn't get propagated to the page view controllers (i.e., it didn't do anything).

Also added a 'bigImages' attribute that increases the image to cover most of the screen (behind the text).  I need to be able to show larger images, like screenshots, in the walkthrough.

Added an 'imageContentMode' attribute that eventually sets the contentMode on the image view so you can set aspectFill, aspectFit, etc.
